### PR TITLE
RPM build fixes

### DIFF
--- a/redhat/make-tarball
+++ b/redhat/make-tarball
@@ -9,7 +9,7 @@ TMPDIR=/tmp/foo$$
 PREVDIR=$PWD
 
 # is there a better way of doing this? 
-TOPDIR=$(rpm  --showrc | awk '$2 ~ /_topdir/ {print $3}')
+TOPDIR=$(rpm -E "$(rpm  --showrc | awk '$2 ~ /_topdir/ {for (x=3; x<=NF; x++){print $x}}')" --quiet 2>/dev/null)
 if [ -z "$TOPDIR" ]; then
     echo "Can't figure out where to put tarball. SOURCES/ unknown"
     exit 255

--- a/redhat/make-tarball
+++ b/redhat/make-tarball
@@ -9,7 +9,7 @@ TMPDIR=/tmp/foo$$
 PREVDIR=$PWD
 
 # is there a better way of doing this? 
-TOPDIR=$(rpm -E "$(rpm  --showrc | awk '$2 ~ /_topdir/ {for (x=3; x<=NF; x++){print $x}}')" --quiet 2>/dev/null)
+TOPDIR=$(rpm -E "$(rpm  --showrc | awk '$2 ~ /_topdir/ {for (x=3; x<=NF-1; x++){printf "%s ", $x}{print $NF}}')" --quiet 2>/dev/null)
 if [ -z "$TOPDIR" ]; then
     echo "Can't figure out where to put tarball. SOURCES/ unknown"
     exit 255

--- a/redhat/varnish-agent.spec
+++ b/redhat/varnish-agent.spec
@@ -16,6 +16,14 @@ Requires: perl-Digest-SHA
 Requires: perl-Config-Simple
 Requires: perl-File-Pid
 Requires: perl-Proc-Daemon
+Requires: perl-IO-Socket-SSL
+
+BuildRequires: perl-Log-Log4perl
+BuildRequires: perl-Digest-SHA
+BuildRequires: perl-Config-Simple
+BuildRequires: perl-File-Pid
+BuildRequires: perl-Proc-Daemon
+BuildRequires: perl-IO-Socket-SSL
 
 Requires(post): /sbin/chkconfig
 Requires(preun): /sbin/chkconfig


### PR DESCRIPTION
Adds a missing Requires tag (perl-IO-Socket-SSL) and missing BuildRequires tags (is an issue when building with mock). Also fixes the `redhat/make-tarball` script to handle spaces in the _topdir macro like: `%_topdir      %(echo $HOME)/rpmbuild`

The BuildRequires tags could be removed if the man page was moved out to a separate file instead of using the --man option to generate it but this was easier.
